### PR TITLE
add gradle dependency on mercurymixin sonatype snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,15 @@ repositories {
     maven {
         url = 'https://repo1.maven.org/maven2'
     }
+    maven {
+        url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
 }
 
 
 dependencies {
-    implementation 'org.cadixdev:mercury:0.1.0.fabric-SNAPSHOT'
+    implementation 'org.cadixdev:mercury:0.1.1.fabric-SNAPSHOT'
+    implementation 'org.cadixdev:mercurymixin:0.1.0-SNAPSHOT'
     implementation 'com.google.code.gson:gson:2.8.6'
 }
 


### PR DESCRIPTION
Right now if you try to use this tool you get a build error. It took me a while to track down where to pull in the mercurymixin package from, but this fixes the build error.

I was able to use the tool successfully for a first pass port of geckolib from MCP to fabric, so thanks!
https://github.com/bernie-g/geckolib/pull/3